### PR TITLE
Should not make the video driver hard fail

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuVideoDxe/Driver.c
+++ b/Platforms/QemuQ35Pkg/QemuVideoDxe/Driver.c
@@ -1077,8 +1077,8 @@ InitializeQemuVideo (
                                  &PolicySize
                                  );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to get USB policy from database - %r!\n", __FUNCTION__, Status));
-    return Status;
+    DEBUG ((DEBUG_WARN, "%a: Failed to get GFX policy from database, configuration is not setup properly - %r! Default to disabled state.\n", __FUNCTION__, Status));
+    mGfxPolicy[0].Power_State_Port = FALSE;
   }
 
   if (PolicySize != sizeof (mGfxPolicy)) {


### PR DESCRIPTION
Changes the logic to send a warning message and default the graphics to off state if the silicon policy is not found.